### PR TITLE
Fixed spelling and grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ As Software Engineers we need to have the discipline to ensure that our code wor
 
 This lab introduces **Test Driven Development** using `PyUnit` and `nose` (a.k.a. `nosetests`). It also demonstrates how to create a simple RESTful service using Python Flask and PostgreSQL. The resource model is persistences using SQLAlchemy to keep the application simple. It's purpose is to show the correct API calls and return codes that should be used for a REST API.
 
-**Note:** The base service code is contained in `routes.py` while the business logic for manipulating Pets is in the `models.py` file. This follows the popular Model View Controller (MVC) separation of duities by keeping the model separate from the controller. As such, we have two tests suites: one for the model (`test_pets.py`) and one for the serveice itself (`test_service.py`)
+**Note:** The base service code is contained in `routes.py` while the business logic for manipulating Pets is in the `models.py` file. This follows the popular Model View Controller (MVC) separation of duities by keeping the model separate from the controller. As such, we have two test suites: one for the model (`test_pets.py`) and one for the service itself (`test_service.py`)
 
 ## Prerequisite Installation using Vagrant
 
-The easiest way to use this lab is with Vagrant and VirtualBox. If you don't have this software the first step is down download and install it. If you have an 2020 Apple Mac with the M1 chip, you should download Docker Desktop instead of VirtualBox. Here is what you need:
+The easiest way to use this lab is with Vagrant and VirtualBox. If you don't have this software the first step is to download and install it. If you have an 2020 or newer Apple Mac with the M1 chip, you should download Docker Desktop instead of VirtualBox. Here is what you need:
 
 Download: [Vagrant](https://www.vagrantup.com/)
 
@@ -41,7 +41,7 @@ vagrant up
 
 ### Using Vagrant and Docker Desktop
 
-You can also use Docker as a provider instead of VirtualBox. This is useful for owners of Apple M1 Silicon Macs which cannot run VirtualBox because they have a CPU based on ARM architecture instead of Intel.
+You can also use Docker as a provider instead of VirtualBox. This is useful for owners of Apple M1 Silicon Macs which cannot run VirtualBox because they have an ARM-based CPU  architecture instead of x86 (Intel).
 
 Just add `--provider docker` to the `vagrant up` command like this:
 
@@ -76,7 +76,7 @@ You should be able to reach the service at: http://localhost:5000
 
 ## Manually running the Tests
 
-As developers we always want to run the tests before we change any code so that we know if we brike the code or perhaps someone before us did? Always run the test cases first!
+As developers we always want to run the tests before we change any code. That way we know if we broke the code or if someone before us did. Always run the test cases first!
 
 Run the tests using `nosetests`
 
@@ -86,13 +86,13 @@ $ nosetests
 
 Nose is configured via the included `setup.cfg` file to automatically include the flags `--with-spec --spec-color` so that red-green-refactor is meaningful. If you are in a command shell that supports colors, passing tests will be green while failing tests will be red.
 
-Nose is also configured to automatically run the `coverage` tool and you should see a percentage of coverage report at the end of your tests. If you want to see what lines of code were not tested use:
+Nose is also configured to automatically run the `coverage` tool and you should see a percentage-of-coverage report at the end of your tests. If you want to see what lines of code were not tested use:
 
 ```shell
 $ coverage report -m
 ```
 
-This is particularly useful because it reports the line numbers for the code that is not covered so that you can write more test cases to get higher code coverage.
+This is particularly useful because it reports the line numbers for the code that have not been covered so you know which lines you want to target with new test cases to get higher code coverage.
 
 You can also manually run `nosetests` with `coverage` (but `setup.cfg` does this already)
 
@@ -108,7 +108,7 @@ It's also a good idea to make sure that your Python code follows the PEP8 standa
 $ flake8 --count --max-complexity=10 --statistics model,service
 ```
 
-I've also include `pylint` in the requirements. If you use a programmer's editor like Atom.io you can install plug-ins that will use `pylint` while you are editing. This catches a lot of errors while you code that would normally be caught at runtime. It's a good idea to always code with pylint active.
+I've also included `pylint` in the requirements. If you use a programmer's editor like Atom.io you can install plug-ins that will use `pylint` while you are editing. This catches a lot of errors while you code that would normally be caught at runtime. It's a good idea to always code with pylint active.
 
 When you are done, you can exit and shut down the vm with:
 


### PR DESCRIPTION
Plus an additional "fix". Apple is moving their entire line up to Apple Silicon so I've added "2020 **or newer** Apple mac"