### PR TITLE
Added green back as alternate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Run unit tests with green
         run: |
           export FLASK_APP=service:app
-          pytest --disable-warnings
+          pytest --pspec --cov=service --cov-fail-under=95 --disable-warnings
         env:
           DATABASE_URI: "postgresql://postgres:pgs3cr3t@postgres:5432/testdb"
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ lint: ## Run the linter
 
 test: ## Run the unit tests
 	$(info Running tests...)
-	pytest --disable-warnings
+	green -vvv --processes=1 --run-coverage --termcolor --minimum-coverage=95
 
 ##@ Runtime
 

--- a/lab/requirements.txt
+++ b/lab/requirements.txt
@@ -6,6 +6,7 @@ python-dotenv==1.0.0
 pytest==7.4.0
 pytest-pspec==0.0.4
 pytest-cov==4.1.0
+green==3.4.3
 
 # Code quality
 pylint==2.17.5

--- a/lab/setup.cfg
+++ b/lab/setup.cfg
@@ -1,6 +1,6 @@
 [tool:pytest]
 minversion = 6.0
-addopts = --pspec --cov=. --disable-warnings
+addopts = --pspec --cov=. --cov-fail-under=95 --disable-warnings
 testpaths =
     tests
     integration
@@ -10,3 +10,11 @@ show_missing = True
 
 [pylint.'MESSAGES CONTROL']
 disable=E1101
+
+[green]
+verbose=3
+processes=1
+run-coverage=1
+termcolor=1
+# minimum-coverage=95
+# junit-report=./unittests.xml

--- a/lab/test_counter.py
+++ b/lab/test_counter.py
@@ -5,7 +5,7 @@ Requirements for the counter service
 - The API must be RESTful.
 - The endpoint must be called `/counters`.
 - When creating a counter, you must specify the name in the path.
-- Duplicate names must return a conflict error code.
+- Duplicate names must return a 409 conflict error code.
 - The service must be able to update a counter by name.
 - The service must be able to get a counter's current value.
 - The service must be able to delete a counter.

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ black==23.7.0
 pytest==7.4.0
 pytest-pspec==0.0.4
 pytest-cov==4.1.0
-
+green==3.4.3
 factory-boy==3.3.0
 coverage==7.3.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,18 @@
 # setup configuration for tools
 [tool:pytest]
 minversion = 6.0
-addopts = --pspec --cov=service --disable-warnings
+addopts = --pspec --cov=service --cov-fail-under=95 --disable-warnings
 testpaths =
     tests
     integration
+
+[green]
+verbose=3
+processes=1
+run-coverage=1
+termcolor=1
+minimum-coverage=95
+# junit-report=./unittests.xml
 
 [flake8]
 max-line-length = 127


### PR DESCRIPTION
I did not update the project template for `pytest` so I'm adding `green` back into this lab so that either can be used

This required the following changes:
* Added `green` back to `requirements.txt` file
* Updated `setup.cfg` with `[green]` stanza
* Updated `setup.cfg` to add `--cov-fail-under=95` to `pytest` options
* Updated GitHub Action `ci.yaml` to add code coverage minimum in the `pytest` checks