### PR TITLE
Fix db-create not working

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ..:/app
     command: sleep infinity
     environment:
-      FLASK_APP: service:app
+      FLASK_APP: wsgi:app
       FLASK_DEBUG: "True"
       GUNICORN_BIND: "0.0.0.0:8000"
       DATABASE_URI: postgresql+psycopg://postgres:pgs3cr3t@postgres:5432/postgres

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ test: ## Run the unit tests
 	$(info Running tests...)
 	pytest --disable-warnings
 
+db-create: ## Creates the database tables
+	$(info Creating database tables...)
+	@flask db-create
+
 ##@ Runtime
 
 run: ## Run the service

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,10 +1,12 @@
 """
 CLI Command Extensions for Flask
 """
+
 import os
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 from click.testing import CliRunner
+
 # pylint: disable=unused-import
 from wsgi import app  # noqa: F401
 from service.common.cli_commands import db_create  # noqa: E402
@@ -16,10 +18,10 @@ class TestFlaskCLI(TestCase):
     def setUp(self):
         self.runner = CliRunner()
 
-    @patch('service.common.cli_commands.db')
+    @patch("service.common.cli_commands.db")
     def test_db_create(self, db_mock):
         """It should call the db-create command"""
         db_mock.return_value = MagicMock()
-        with patch.dict(os.environ, {"FLASK_APP": "service:app"}, clear=True):
+        with patch.dict(os.environ, {"FLASK_APP": "wsgi:app"}, clear=True):
             result = self.runner.invoke(db_create)
             self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
The `db-create` command stopped working when I switched to using `wsgi.py` and the Flask app factory pattern.

Made the following changes to fix this
- Changed value of `FLASK_APP` from `service:app` to `wsgi:app` in `.devcontainer/docker-compose.yml` file
- Change CLI test case to point to `wsgi:app`
- Added a new `db-create` target to the `Makefile`